### PR TITLE
Fix GitHub Pages Deployment 404

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -55,7 +55,7 @@ jobs:
         run: npm run build
         env:
           NEXT_BUILD_MODE: 'static-export'
-          GITHUB_ACTIONS: true 
+          ENABLE_BASE_PATH: 'true' 
 
       - name: Upload artifact
         uses: actions/upload-pages-artifact@v3

--- a/web/next.config.ts
+++ b/web/next.config.ts
@@ -4,15 +4,15 @@ import createNextIntlPlugin from 'next-intl/plugin';
 const withNextIntl = createNextIntlPlugin('./i18n/request.ts');
 
 const nextBuildMode = process.env.NEXT_BUILD_MODE; // e.g., 'static-export'
-const isGithubActions = process.env.GITHUB_ACTIONS || false;
+const enableBasePath = process.env.ENABLE_BASE_PATH === 'true';
 // Assuming your repo name is 'hzz-gc'. If you rename it, update this line.
 const repoName = 'hzz-gc'; 
 
 const nextConfig: NextConfig = {
   output: nextBuildMode === 'static-export' ? 'export' : 'standalone',
-  basePath: nextBuildMode === 'static-export' ? '' : isGithubActions ? `/${repoName}` : '',
+  basePath: enableBasePath ? `/${repoName}` : '',
   images: {
-    unoptimized: isGithubActions ? true : false, // Required for static export (GH Pages)
+    unoptimized: true, // Always required for static export (GH Pages)
   }
 };
 


### PR DESCRIPTION
Sets basePath to /hzz-gc only during deployment (via explicit ENABLE_BASE_PATH env var), fixing 404 errors on GitHub Pages while keeping local tests working.